### PR TITLE
🎨 Palette: Accessibility & Form Feedback Improvements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,5 @@
+## PALETTE'S JOURNAL
+
+## 2026-03-17 - Icon-only buttons accessibility & Form feedback
+**Learning:** Icon-only buttons used for primary navigation and table actions (`FloatingMenu`, `CharacterListView`) frequently lacked `aria-label` attributes, creating a barrier for screen reader users. Additionally, asynchronous form submissions (like `LoginForm`) lacked immediate feedback indicating processing status, potentially leading to double-submissions or user confusion.
+**Action:** Consistently enforce `aria-label`s on any button lacking text content. Incorporate loading states (`isLoading`) paired with visual indicators (like `Loader2` from `lucide-react`) and disable interactions (`disabled={isLoading}`) on primary action buttons triggering asynchronous events.

--- a/components/CharacterListView.tsx
+++ b/components/CharacterListView.tsx
@@ -113,7 +113,7 @@ export function CharacterListView({
                 <TableCell className="text-right">
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
-                      <Button variant="ghost" className="h-8 w-8 p-0">
+                      <Button variant="ghost" className="h-8 w-8 p-0" aria-label="Mais ações">
                         <MoreHorizontal className="h-4 w-4" />
                       </Button>
                     </DropdownMenuTrigger>

--- a/components/floating-menu.tsx
+++ b/components/floating-menu.tsx
@@ -9,14 +9,6 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuLabel,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { ModeToggle } from "@/components/theme-toggle";
 import {
@@ -25,7 +17,6 @@ import {
   Crown,
   LayoutDashboard,
   LogOut,
-  Sparkles,
   Swords,
   User,
   UserCircle,
@@ -85,6 +76,7 @@ export function FloatingMenu() {
         <PopoverTrigger asChild>
           <Button
             size="icon"
+            aria-label="Abrir menu de navegação"
             className="h-14 w-14 rounded-full shadow-lg shadow-primary/50 transition-all hover:scale-110 hover:shadow-primary/70 bg-primary text-primary-foreground hover:opacity-90"
           >
             <AlignJustify className="h-6 w-6" />

--- a/components/login-form.tsx
+++ b/components/login-form.tsx
@@ -13,16 +13,20 @@ import { FormEvent, useState } from "react";
 import { signIn } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
+import { Loader2 } from "lucide-react";
 
 export function LoginForm({
   className,
   ...props
 }: React.ComponentPropsWithoutRef<"div">) {
   const [error, setError] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
   const router = useRouter();
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    setIsLoading(true);
+    setError("");
     const formData = new FormData(event.currentTarget);
     const res = await signIn("credentials", {
       email: formData.get("email"),
@@ -31,6 +35,7 @@ export function LoginForm({
     });
     if (res?.error) {
       setError(res.error as string);
+      setIsLoading(false);
     }
     if (res?.ok) {
       return router.push("/dashboard");
@@ -71,8 +76,15 @@ export function LoginForm({
                 </div>
                 <Input id="password" type="password" name="password" />
               </div>
-              <Button type="submit" className="w-full">
-                Login
+              <Button type="submit" className="w-full" disabled={isLoading}>
+                {isLoading ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Entrando...
+                  </>
+                ) : (
+                  "Login"
+                )}
               </Button>
             </div>
             <div className="mt-4 text-center text-sm">


### PR DESCRIPTION
🎨 Palette: Accessibility & Form Feedback Improvements

💡 **What:**
- Added `aria-label` attributes to the icon-only buttons in `FloatingMenu` ("Abrir menu de navegação") and `CharacterListView` ("Mais ações").
- Implemented an `isLoading` state in `LoginForm` to disable the submit button and show a "Entrando..." spinner while authenticating.
- Created `.Jules/palette.md` to document UX/a11y learnings regarding icon-only buttons and form feedback.

🎯 **Why:**
- Without `aria-label`s, screen reader users miss crucial context for interactive elements like menus and action dropdowns.
- Form submissions without loading states fail to reassure users that their request is processing, which can lead to double-submissions and confusion.

📸 **Before/After:**
*(Visual changes verified locally via Playwright)*
- The "Login" button now transitions to a disabled state with a spinner reading "Entrando..." during the sign-in network request.

♿ **Accessibility:**
- Significantly improved screen reader compatibility for two critical, frequently-used navigation and action components.
- Ensured keyboard accessibility isn't hindered during form submission logic.

---
*PR created automatically by Jules for task [4596065735056993717](https://jules.google.com/task/4596065735056993717) started by @HensleyFerrari*