### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix IDOR in updateCharacterStatus

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Insecure Direct Object Reference (IDOR) on `updateNPC` and `deleteNPC` in `lib/actions/NPC.actions.ts`. Any authenticated user could update or delete any NPC, bypassing ownership and campaign master checks.
 **Learning:** Server Actions must validate the ownership of resources directly, even when UI components restrict certain elements based on state, because they are direct API endpoints.
 **Prevention:** Always verify resource ownership directly in the server actions using methods like `checkOwnership` and `verifyCampaignOwner` against the current authenticated user session before performing mutations.
+## 2025-10-24 - Fix IDOR in character status toggle
+**Vulnerability:** IDOR in `updateCharacterStatus` allowed any user to toggle character status (`alive`/`dead`) by providing a valid character ID, without verifying ownership or campaign GM status.
+**Learning:** Single-field toggle functions require the same robust authorization checks (`checkOwnership`, `verifyCampaignOwner`, `canEditCharacter`) as full update endpoints, otherwise they are vulnerable to unauthorized modifications.
+**Prevention:** Always ensure the user executing a mutation action is authorized to modify the target resource before executing the `findByIdAndUpdate` (or equivalent) database query.

--- a/lib/actions/character.actions.ts
+++ b/lib/actions/character.actions.ts
@@ -631,6 +631,26 @@ export async function updateCharacterStatus(
       };
     }
 
+    const actualUser = await getCurrentUser();
+    if (!actualUser) {
+      return { ok: false, message: "Usuário não autenticado" };
+    }
+
+    const characterData = await Character.findById(characterId).populate("campaign");
+    if (!characterData) {
+      return {
+        ok: false,
+        message: "Personagem não encontrado",
+      };
+    }
+
+    if (!canEditCharacter(characterData, actualUser._id)) {
+      return {
+        ok: false,
+        message: "Você não tem permissão para editar este personagem",
+      };
+    }
+
     const updatedCharacter = await Character.findByIdAndUpdate(
       characterId,
       { status },


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Insecure Direct Object Reference (IDOR) in `updateCharacterStatus` allowed any user to toggle character status (`alive`/`dead`) simply by providing a valid character ID, as the action lacked ownership or campaign GM validation.
🎯 Impact: Unauthorized users could alter the status of characters they did not own and were not managing in their campaigns, potentially griefing other players' characters.
🔧 Fix: Added proper authentication and authorization checks. Fetches the current user via `getCurrentUser()`, loads the character and populates the campaign, and uses the `canEditCharacter` utility to ensure only the character's owner or the campaign's GM can modify the status.
✅ Verification: Ran `pnpm test` and `pnpm lint` locally. All tests pass, including character action unit tests.

---
*PR created automatically by Jules for task [16737252111094279420](https://jules.google.com/task/16737252111094279420) started by @HensleyFerrari*