### PR TITLE
🎨 Palette: Adiciona aria-labels para botões somente com ícones

### DIFF
--- a/app/dashboard/battles/battles-client.tsx
+++ b/app/dashboard/battles/battles-client.tsx
@@ -193,7 +193,7 @@ const BattleList = ({ battles, currentUser, onEdit }: { battles: any[], currentU
             </Button>
 
             {/* Desktop Action Button */}
-            <Button variant="ghost" size="icon" className="h-8 w-8 hover:bg-slate-200 dark:hover:bg-slate-700 rounded-lg hidden md:flex" asChild>
+            <Button variant="ghost" size="icon" className="h-8 w-8 hover:bg-slate-200 dark:hover:bg-slate-700 rounded-lg hidden md:flex" aria-label="Ver detalhes da batalha" asChild>
               <Link href={`/dashboard/battles/${battle._id}`}>
                 <ChevronRight className="h-5 w-5 text-slate-400" />
               </Link>
@@ -202,7 +202,7 @@ const BattleList = ({ battles, currentUser, onEdit }: { battles: any[], currentU
             {currentUser?._id === battle.owner?._id && (
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                  <Button variant="ghost" size="icon" className="h-8 w-8 hover:bg-slate-200 dark:hover:bg-slate-700 rounded-lg shrink-0">
+                  <Button variant="ghost" size="icon" className="h-8 w-8 hover:bg-slate-200 dark:hover:bg-slate-700 rounded-lg shrink-0" aria-label="Opções da batalha">
                     <MoreVertical className="h-4 w-4 text-slate-400" />
                   </Button>
                 </DropdownMenuTrigger>

--- a/app/dashboard/campaigns/[id]/page.tsx
+++ b/app/dashboard/campaigns/[id]/page.tsx
@@ -73,7 +73,7 @@ const CampaignDetail = async ({ params }: any) => {
           <div className="flex items-center gap-2">
             {isOwner && (
               <Link href={`?edit=${id}`}>
-                <Button variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground hover:text-foreground">
+                <Button variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground hover:text-foreground" aria-label="Editar campanha">
                   <Edit3 className="h-4 w-4" />
                 </Button>
               </Link>

--- a/app/dashboard/campaigns/page.tsx
+++ b/app/dashboard/campaigns/page.tsx
@@ -166,7 +166,7 @@ const CampaignsPage = async ({
                         {isOwner && (
                           <DropdownMenu>
                             <DropdownMenuTrigger asChild>
-                              <Button variant="ghost" size="icon" className="h-8 w-8">
+                              <Button variant="ghost" size="icon" className="h-8 w-8" aria-label="Opções da campanha">
                                 <MoreVertical className="h-4 w-4" />
                               </Button>
                             </DropdownMenuTrigger>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -238,7 +238,7 @@ const Dashboard = async () => {
                         </p>
                       </div>
                     </div>
-                    <Button variant="ghost" size="icon" className="h-8 w-8" asChild>
+                    <Button variant="ghost" size="icon" className="h-8 w-8" aria-label="Ir para a batalha" asChild>
                       <Link href={`/dashboard/battles/${battle._id}`}>
                         <ArrowRight className="h-4 w-4" />
                       </Link>

--- a/app/dashboard/personagens/[id]/page.tsx
+++ b/app/dashboard/personagens/[id]/page.tsx
@@ -186,7 +186,7 @@ const CharacterPage = () => {
           {hasEditPermission && (
             <div className="flex items-center gap-2">
               <Link href={`?editCharacter=${id}`}>
-                <Button variant="ghost" size="icon" className="h-8 w-8 hover:bg-muted">
+                <Button variant="ghost" size="icon" className="h-8 w-8 hover:bg-muted" aria-label="Editar personagem">
                   <Edit className="w-4 h-4 text-muted-foreground" />
                 </Button>
               </Link>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -204,7 +204,7 @@ export default function Home() {
             © 2026 Drpg. Todos os direitos reservados.
           </p>
           <div className="flex gap-6">
-            <Button variant="ghost" size="icon" className="text-muted-foreground hover:text-foreground">
+            <Button variant="ghost" size="icon" className="text-muted-foreground hover:text-foreground" aria-label="Link para o Github">
               <Github className="h-5 w-5" />
             </Button>
           </div>


### PR DESCRIPTION
## 🎨 Palette: Adiciona aria-labels para botões somente com ícones

**💡 What:** Added `aria-label` attributes in Portuguese to several icon-only `<Button>` components across the application.
**🎯 Why:** Icon-only buttons without accessible names cannot be understood by screen readers, creating an accessibility barrier. This change ensures that every interactive button provides clear context to assistive technologies.
**♿ Accessibility:** Improves WCAG compliance by providing text alternatives for graphical buttons.

Changes made in:
- `app/dashboard/campaigns/page.tsx`
- `app/dashboard/campaigns/[id]/page.tsx`
- `app/dashboard/personagens/[id]/page.tsx`
- `app/dashboard/battles/battles-client.tsx`
- `app/page.tsx`
- `app/dashboard/page.tsx`

---
*PR created automatically by Jules for task [1042593946921796882](https://jules.google.com/task/1042593946921796882) started by @HensleyFerrari*