### PR TITLE
Fix: replace window.location with Next.js router for client-side navigation

### DIFF
--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -23,6 +23,7 @@ import {
 import { toast } from "sonner";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useRouter } from "next/navigation";
 import * as z from "zod";
 import {
   Form,
@@ -122,6 +123,7 @@ function ChangePasswordForm() {
 export default function SettingsPage() {
   const [avatarUrl, setAvatarUrl] = useState("");
   const [user, setUser] = useState<any>(null);
+  const router = useRouter();
 
   useEffect(() => {
     const fetchUser = async () => {
@@ -131,12 +133,12 @@ export default function SettingsPage() {
         setAvatarUrl(userData.avatarUrl || "");
       } else {
         // Redirect to login if no user is found
-        window.location.href = "/login";
+        router.push("/login");
       }
     };
 
     fetchUser();
-  }, []);
+  }, [router]);
 
   const handleAvatarUpdate = async () => {
     if (!user) {

--- a/components/floating-menu.tsx
+++ b/components/floating-menu.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import { useState, useEffect } from "react";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import {
   Popover,
   PopoverContent,
@@ -54,6 +54,7 @@ const items = [
 
 export function FloatingMenu() {
   const pathname = usePathname();
+  const router = useRouter();
   const [actualUser, setActualUser] = useState<{
     name?: string;
     avatarUrl?: string;
@@ -154,7 +155,7 @@ export function FloatingMenu() {
                   className="flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-all group text-red-500 hover:bg-red-500/10 hover:text-red-500"
                   onClick={() => {
                     signOut({ redirect: false }).then(() => {
-                      window.location.href = "/";
+                      router.push("/");
                     });
                   }}
                 >

--- a/components/ui/refresh-button.tsx
+++ b/components/ui/refresh-button.tsx
@@ -2,13 +2,13 @@
 
 import { Button } from "./button";
 import { RefreshCcw } from "lucide-react";
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 
 const RefreshButton = () => {
   const router = useRouter();
+  const pathname = usePathname();
   const handleRefresh = () => {
-    const currentPath = window.location.pathname;
-    router.push(currentPath);
+    router.push(pathname);
   };
 
   return (


### PR DESCRIPTION
This PR replaces instances of `window.location.href` and `window.location.pathname` with Next.js's native `useRouter` and `usePathname` hooks. Using `window.location` directly can sometimes lead to security vulnerabilities (like open redirects or XSS if misused) and it also breaks the Single Page Application (SPA) feel of Next.js by causing full page reloads. This change ensures we use standard React best practices for navigation.

Changes made:
- `app/dashboard/settings/page.tsx`: Replaced `window.location.href = "/login"` with `router.push("/login")`.
- `components/floating-menu.tsx`: Replaced `window.location.href = "/"` with `router.push("/")` inside the `signOut` callback.
- `components/ui/refresh-button.tsx`: Replaced `window.location.pathname` with `usePathname` and updated the refresh logic.

---
*PR created automatically by Jules for task [2478005754018354962](https://jules.google.com/task/2478005754018354962) started by @HensleyFerrari*