### PR TITLE
🎨 Palette: Melhoria de acessibilidade em botões de ícone

### DIFF
--- a/app/dashboard/campaigns/[id]/_components/character-card-actions.tsx
+++ b/app/dashboard/campaigns/[id]/_components/character-card-actions.tsx
@@ -55,9 +55,8 @@ export function CharacterCardActions({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="icon" className="h-8 w-8" disabled={isLoading}>
+        <Button variant="ghost" size="icon" className="h-8 w-8" disabled={isLoading} aria-label="Opções do personagem">
             {isLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <MoreHorizontal className="h-4 w-4" />}
-          <span className="sr-only">Abrir menu</span>
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { GlobalModals } from "./_components/global-modals";
 import { DashboardBreadcrumb } from "@/components/dashboard-breadcrumb";
 import { FloatingMenu } from "@/components/floating-menu";
+import { Suspense } from "react";
 
 export const metadata: Metadata = {
   title: "Drpg - Dashboard",
@@ -19,7 +20,9 @@ export default async function RootLayout({
         <DashboardBreadcrumb />
       </header>
       <div className="flex flex-1 flex-col gap-4 p-8">
-        <GlobalModals />
+        <Suspense fallback={null}>
+          <GlobalModals />
+        </Suspense>
         {children}
       </div>
       <FloatingMenu />

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -23,6 +23,7 @@ import {
 import Image from "next/image";
 import { CharacterAvatar } from "@/components/CharacterAvatar";
 import { CampaignModal } from "./campaigns/components/campaign-modal";
+import { Suspense } from "react";
 
 export const dynamic = 'force-dynamic';
 
@@ -55,7 +56,9 @@ const Dashboard = async () => {
 
   return (
     <div className="flex flex-col gap-8 p-6 max-w-7xl mx-auto w-full">
-      <CampaignModal />
+      <Suspense fallback={null}>
+        <CampaignModal />
+      </Suspense>
 
       {/* Header Section */}
       <div className="space-y-4">
@@ -284,7 +287,7 @@ const Dashboard = async () => {
                         </p>
                       </div>
                     </div>
-                    <Button variant="ghost" size="icon" className="h-8 w-8" asChild>
+                    <Button variant="ghost" size="icon" className="h-8 w-8" aria-label="Ir para o personagem" asChild>
                       <Link href={`/dashboard/personagens/${char._id}`}>
                         <ArrowRight className="h-4 w-4" />
                       </Link>

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -18,10 +18,9 @@ export function ModeToggle() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline" size="icon">
+        <Button variant="outline" size="icon" aria-label="Alternar tema">
           <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
           <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
-          <span className="sr-only">Toggle theme</span>
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">


### PR DESCRIPTION
- 💡 What: Adicionados atributos `aria-label` a botões formados apenas por ícones (`Button` do shadcn). Em alguns lugares, `sr-only` span text foi removido e trocado pela propriedade mais apropriada no próprio botão. Adicionado também `Suspense` em torno de partes da UI que quebravam o build pela falta dele.
- 🎯 Why: Melhorar a acessibilidade para leitores de tela na plataforma e criar maior padronização de UI conforme as documentações de melhores práticas.
- ♿ Accessibility: Leitores de tela agora poderão interpretar adequadamente os botões de: alternância de tema, menu extra em "cartões de personagem" e os links para páginas de visualização de personagens do usuário.

---
*PR created automatically by Jules for task [12357615687967370819](https://jules.google.com/task/12357615687967370819) started by @HensleyFerrari*