### PR TITLE
🎨 Palette: Add ARIA label to back button in Breadcrumb

### DIFF
--- a/components/ui/breadcrumb.tsx
+++ b/components/ui/breadcrumb.tsx
@@ -34,6 +34,7 @@ function Breadcrumb({ items, className, showBackButton = true, ...props }: Bread
           className="h-6 w-6 mr-2 shrink-0"
           onClick={() => router.back()}
           title="Voltar"
+          aria-label="Voltar"
         >
           <ArrowLeft className="h-4 w-4" />
         </Button>


### PR DESCRIPTION
💡 **What:** Added `aria-label="Voltar"` to the icon-only "back" button inside the `Breadcrumb` component.

🎯 **Why:** The button previously only had a `title="Voltar"` attribute but lacked an `aria-label`. Icon-only buttons need an explicit ARIA label for screen readers to properly announce their function, improving accessibility for visually impaired users. This aligns with standard UX/a11y best practices.

♿ **Accessibility:**
- Added `aria-label="Voltar"` to `<Button variant="ghost" size="icon">` in `components/ui/breadcrumb.tsx`.

---
*PR created automatically by Jules for task [3724665099539516516](https://jules.google.com/task/3724665099539516516) started by @HensleyFerrari*