### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix ReDoS vulnerability in $regex queries

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -10,3 +10,7 @@
 **Vulnerability:** The `register` server action (`actions/register.ts`) trusted client-provided inputs (`values: any`) without validating them on the server-side, potentially exposing the application to injection or invalid data and it was logging raw errors `console.log(e)` which could leak sensitive internal details.
 **Learning:** Client-side validation is easily bypassed. Server actions must implement strict server-side input validation and error handling to ensure data integrity and prevent information leakage.
 **Prevention:** Always use a validation library like `zod` to validate all incoming data in server actions before processing it, and use generic error messages in catch blocks.
+## 2025-10-26 - Fix ReDoS Vulnerability in MongoDB $regex queries
+**Vulnerability:** The application passed user input directly to the `$regex` operator in MongoDB queries for `getCampaigns` and `getBattles`. This could allow attackers to perform Regular Expression Denial of Service (ReDoS) attacks by crafting complex regex strings.
+**Learning:** Any user input that is passed to a regex evaluation engine needs to be sanitized to prevent attackers from sending deliberately slow-to-evaluate regexes that can freeze the application or database.
+**Prevention:** Always escape regex special characters from user input before passing it to MongoDB `$regex` or the JavaScript `RegExp` constructor. A utility function `escapeRegExp` was added to `lib/utils.ts` and applied where needed.

--- a/lib/actions/battle.actions.ts
+++ b/lib/actions/battle.actions.ts
@@ -10,7 +10,7 @@ import { getCurrentUser } from "./user.actions";
 import { getAllDamagesByBattleId } from "./damage.actions";
 import { triggerBattleUpdate } from "../pusher";
 import { safeAction } from "./safe-action";
-import { serializeData } from "../utils";
+import { serializeData, escapeRegExp } from "../utils";
 import { verifyBattleMaster } from "../auth";
 
 export const createBattle = async (BattleParams: any) => {
@@ -313,7 +313,7 @@ export const getBattles = async ({
     const queryObj: any = {};
 
     if (query) {
-      queryObj.name = { $regex: query, $options: "i" };
+      queryObj.name = { $regex: escapeRegExp(query), $options: "i" };
     }
 
     if (filterType === "my") {

--- a/lib/actions/campaign.actions.ts
+++ b/lib/actions/campaign.actions.ts
@@ -15,7 +15,7 @@ interface CampaignResponse {
   data?: CampaignDocument | CampaignDocument[] | null;
 }
 
-import { serializeData } from "../utils";
+import { serializeData, escapeRegExp } from "../utils";
 
 export async function getCampaigns({
   query,
@@ -25,7 +25,7 @@ export async function getCampaigns({
     const queryObj: any = {};
 
     if (query) {
-      queryObj.name = { $regex: query, $options: "i" };
+      queryObj.name = { $regex: escapeRegExp(query), $options: "i" };
     }
 
     if (filterType === "my") {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -9,6 +9,10 @@ export const serializeData = (data: any) => {
   return JSON.parse(JSON.stringify(data));
 };
 
+export function escapeRegExp(string: string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); // $& means the whole matched string
+}
+
 export interface ServerActionResponse<T = any> {
   ok: boolean;
   message: string;


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Unsanitized user input was being directly passed into MongoDB `$regex` operators in `getCampaigns` and `getBattles`.
🎯 **Impact:** An attacker could exploit this by providing a complex regex string, causing a Regular Expression Denial of Service (ReDoS) attack that could severely degrade database performance or cause a denial of service.
🔧 **Fix:** Introduced an `escapeRegExp` utility function in `lib/utils.ts` to escape special regex characters and applied it to user input before using it in `$regex` queries.
✅ **Verification:** Verified that searches still work as expected and that `pnpm test`, `pnpm build`, and `pnpm lint` pass successfully.

---
*PR created automatically by Jules for task [7176855693633557666](https://jules.google.com/task/7176855693633557666) started by @HensleyFerrari*