### PR TITLE
🎨 Palette: Improve accessibility of icon-only buttons

### DIFF
--- a/app/dashboard/battles/[id]/components/battle-history.tsx
+++ b/app/dashboard/battles/[id]/components/battle-history.tsx
@@ -28,29 +28,32 @@ export const BattleHistory = memo(function BattleHistory({
   currentUser,
   onOpenTurnDetails,
 }: BattleHistoryProps) {
-  const allyDamage = battle.rounds?.reduce(
-    (acc, round) =>
-      acc +
-      (round.type !== "heal" &&
-      (!round.character?.alignment || round.character.alignment === "ally")
-        ? round.damage
-        : 0),
-    0
-  ) ?? 0;
+  const allyDamage =
+    battle.rounds?.reduce(
+      (acc, round) =>
+        acc +
+        (round.type !== "heal" &&
+        (!round.character?.alignment || round.character.alignment === "ally")
+          ? round.damage
+          : 0),
+      0,
+    ) ?? 0;
 
-  const enemyDamage = battle.rounds?.reduce(
-    (acc, round) =>
-      acc +
-      (round.type !== "heal" && round.character?.alignment === "enemy"
-        ? round.damage
-        : 0),
-    0
-  ) ?? 0;
+  const enemyDamage =
+    battle.rounds?.reduce(
+      (acc, round) =>
+        acc +
+        (round.type !== "heal" && round.character?.alignment === "enemy"
+          ? round.damage
+          : 0),
+      0,
+    ) ?? 0;
 
-  const totalHeal = battle.rounds?.reduce(
-    (acc, round) => acc + (round.type === "heal" ? round.damage : 0),
-    0
-  ) ?? 0;
+  const totalHeal =
+    battle.rounds?.reduce(
+      (acc, round) => acc + (round.type === "heal" ? round.damage : 0),
+      0,
+    ) ?? 0;
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-3 gap-12">
@@ -69,7 +72,7 @@ export const BattleHistory = memo(function BattleHistory({
                       ? "bg-green-500/5 border-green-500/20 hover:bg-green-500/10"
                       : round.isCritical
                         ? "bg-amber-500/5 border-amber-500/20 hover:bg-amber-500/10"
-                        : "border-border/50 hover:border-border"
+                        : "border-border/50 hover:border-border",
                 )}
               >
                 <div className="shrink-0">
@@ -96,7 +99,7 @@ export const BattleHistory = memo(function BattleHistory({
                           "font-semibold text-sm sm:text-base truncate",
                           round.character?.alignment === "enemy"
                             ? "text-red-500"
-                            : "text-foreground"
+                            : "text-foreground",
                         )}
                       >
                         {round.character?.name || "Evento"}
@@ -112,24 +115,19 @@ export const BattleHistory = memo(function BattleHistory({
                       ) : null}
                     </div>
 
-                    {(round.type === "other" || round.description) ? (
+                    {round.type === "other" || round.description ? (
                       <div className="text-xs sm:text-sm text-muted-foreground italic min-w-0">
                         {round.type === "other" &&
                         round.description?.startsWith("[TURNO_ALTERADO]") ? (
                           <span className="text-blue-500 font-medium not-italic flex items-center gap-1">
                             <History className="h-3 w-3" />
-                            {round.description.replace(
-                              "[TURNO_ALTERADO] ",
-                              ""
-                            )}
+                            {round.description.replace("[TURNO_ALTERADO] ", "")}
                           </span>
-                        ) : (
-                          round.description ? (
-                            <p className="line-clamp-2 border-l-2 border-primary/20 pl-2">
-                              {round.description}
-                            </p>
-                          ) : null
-                        )}
+                        ) : round.description ? (
+                          <p className="line-clamp-2 border-l-2 border-primary/20 pl-2">
+                            {round.description}
+                          </p>
+                        ) : null}
                       </div>
                     ) : null}
                   </div>
@@ -150,7 +148,7 @@ export const BattleHistory = memo(function BattleHistory({
                               "flex items-center gap-1.5 px-3 py-1 rounded-full text-sm shadow-sm border",
                               round.isCritical
                                 ? "text-amber-100 bg-amber-600 border-amber-500"
-                                : "text-zinc-100 bg-zinc-600 border-zinc-500"
+                                : "text-zinc-100 bg-zinc-600 border-zinc-500",
                             )}
                           >
                             <SwordsIcon className="h-3.5 w-3.5" />
@@ -178,6 +176,7 @@ export const BattleHistory = memo(function BattleHistory({
                       variant="ghost"
                       size="icon"
                       className="h-6 w-6 text-muted-foreground hover:text-foreground opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity"
+                      aria-label="Ver detalhes do turno"
                       onClick={() => onOpenTurnDetails(round)}
                     >
                       <Info className="h-4 w-4" />

--- a/app/dashboard/battles/[id]/components/turn-details-modal.tsx
+++ b/app/dashboard/battles/[id]/components/turn-details-modal.tsx
@@ -45,7 +45,7 @@ import {
   User,
   Target,
   CalendarIcon,
-  Trash
+  Trash,
 } from "lucide-react";
 
 interface TurnDetailsModalProps {
@@ -77,8 +77,11 @@ export function TurnDetailsModal({
   const [isDeleting, setIsDeleting] = useState(false);
 
   // Determine permissions
-  const isOwner = currentUser?._id === turn?.owner?._id || currentUser?._id === turn?.owner;
-  const isGM = currentUser?._id === battle?.owner?._id || currentUser?._id === battle?.owner;
+  const isOwner =
+    currentUser?._id === turn?.owner?._id || currentUser?._id === turn?.owner;
+  const isGM =
+    currentUser?._id === battle?.owner?._id ||
+    currentUser?._id === battle?.owner;
   const canEdit = isOwner || isGM;
 
   const form = useForm<z.infer<typeof formSchema>>({
@@ -121,8 +124,8 @@ export function TurnDetailsModal({
       if (result.ok) {
         toast.success("Turno atualizado com sucesso");
         setIsEditing(false);
-        // Close modal or keep open with updated data? 
-        // Logic usually updates parent via revalidatePath/pusher, preventing stale data might require closing or refetching. 
+        // Close modal or keep open with updated data?
+        // Logic usually updates parent via revalidatePath/pusher, preventing stale data might require closing or refetching.
         // For now, let's keep it simple.
         onOpenChange(false);
       } else {
@@ -167,10 +170,13 @@ export function TurnDetailsModal({
   const battleCharacters = battle?.characters || [];
 
   return (
-    <Dialog open={open} onOpenChange={(val) => {
-      onOpenChange(val);
-      if (!val) setIsEditing(false); // Reset edit mode on close
-    }}>
+    <Dialog
+      open={open}
+      onOpenChange={(val) => {
+        onOpenChange(val);
+        if (!val) setIsEditing(false); // Reset edit mode on close
+      }}
+    >
       <DialogContent className="sm:max-w-[500px]">
         <DialogHeader>
           <div className="flex items-center justify-between pr-8">
@@ -179,29 +185,38 @@ export function TurnDetailsModal({
               <DialogTitle>Detalhes do Turno</DialogTitle>
             </div>
             {canEdit && !isEditing && (
-              <Button variant="ghost" size="sm" onClick={() => {
-                form.reset({
-                  character: turn?.character?._id || "",
-                  target: turn?.target?._id || "none",
-                  type: turn?.type || "damage",
-                  damage: turn?.damage || 0,
-                  description: turn?.description || "",
-                  isCritical: turn?.isCritical || false,
-                });
-                setIsEditing(true);
-              }}>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  form.reset({
+                    character: turn?.character?._id || "",
+                    target: turn?.target?._id || "none",
+                    type: turn?.type || "damage",
+                    damage: turn?.damage || 0,
+                    description: turn?.description || "",
+                    isCritical: turn?.isCritical || false,
+                  });
+                  setIsEditing(true);
+                }}
+              >
                 <Pencil className="w-4 h-4 mr-1" /> Editar
               </Button>
             )}
           </div>
           <DialogDescription>
-            {isEditing ? "Edite as informações do turno." : "Informações detalhadas sobre este evento na batalha."}
+            {isEditing
+              ? "Edite as informações do turno."
+              : "Informações detalhadas sobre este evento na batalha."}
           </DialogDescription>
         </DialogHeader>
 
         {isEditing ? (
           <Form {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4 py-2">
+            <form
+              onSubmit={form.handleSubmit(onSubmit)}
+              className="space-y-4 py-2"
+            >
               <FormField
                 control={form.control}
                 name="type"
@@ -209,7 +224,11 @@ export function TurnDetailsModal({
                   <FormItem>
                     <FormLabel>Tipo</FormLabel>
                     <FormControl>
-                      <Tabs onValueChange={field.onChange} defaultValue={field.value} className="w-full">
+                      <Tabs
+                        onValueChange={field.onChange}
+                        defaultValue={field.value}
+                        className="w-full"
+                      >
                         <TabsList className="grid w-full grid-cols-3">
                           <TabsTrigger value="damage">Dano</TabsTrigger>
                           <TabsTrigger value="heal">Cura</TabsTrigger>
@@ -233,7 +252,9 @@ export function TurnDetailsModal({
                           <Input
                             type="number"
                             {...field}
-                            onChange={e => field.onChange(parseInt(e.target.value) || 0)}
+                            onChange={(e) =>
+                              field.onChange(parseInt(e.target.value) || 0)
+                            }
                           />
                         </FormControl>
                       </FormItem>
@@ -245,9 +266,16 @@ export function TurnDetailsModal({
                   control={form.control}
                   name="character"
                   render={({ field }) => (
-                    <FormItem className={form.watch("type") === "other" ? "col-span-2" : ""}>
+                    <FormItem
+                      className={
+                        form.watch("type") === "other" ? "col-span-2" : ""
+                      }
+                    >
                       <FormLabel>Origem</FormLabel>
-                      <Select onValueChange={field.onChange} defaultValue={field.value}>
+                      <Select
+                        onValueChange={field.onChange}
+                        defaultValue={field.value}
+                      >
                         <FormControl>
                           <SelectTrigger>
                             <SelectValue placeholder="Selecione..." />
@@ -255,7 +283,9 @@ export function TurnDetailsModal({
                         </FormControl>
                         <SelectContent>
                           {battleCharacters.map((char: any) => (
-                            <SelectItem key={char._id} value={char._id}>{char.name}</SelectItem>
+                            <SelectItem key={char._id} value={char._id}>
+                              {char.name}
+                            </SelectItem>
                           ))}
                         </SelectContent>
                       </Select>
@@ -272,7 +302,10 @@ export function TurnDetailsModal({
                     render={({ field }) => (
                       <FormItem>
                         <FormLabel>Alvo</FormLabel>
-                        <Select onValueChange={field.onChange} defaultValue={field.value}>
+                        <Select
+                          onValueChange={field.onChange}
+                          defaultValue={field.value}
+                        >
                           <FormControl>
                             <SelectTrigger>
                               <SelectValue placeholder="Nenhum" />
@@ -281,7 +314,9 @@ export function TurnDetailsModal({
                           <SelectContent>
                             <SelectItem value="none">Nenhum</SelectItem>
                             {battleCharacters.map((char: any) => (
-                              <SelectItem key={char._id} value={char._id}>{char.name}</SelectItem>
+                              <SelectItem key={char._id} value={char._id}>
+                                {char.name}
+                              </SelectItem>
                             ))}
                           </SelectContent>
                         </Select>
@@ -295,7 +330,10 @@ export function TurnDetailsModal({
                     render={({ field }) => (
                       <FormItem className="flex flex-row items-center space-x-2 space-y-0 rounded-md border p-3 mt-auto">
                         <FormControl>
-                          <Checkbox checked={field.value} onCheckedChange={field.onChange} />
+                          <Checkbox
+                            checked={field.value}
+                            onCheckedChange={field.onChange}
+                          />
                         </FormControl>
                         <FormLabel className="font-normal cursor-pointer">
                           Crítico?
@@ -313,7 +351,10 @@ export function TurnDetailsModal({
                   <FormItem>
                     <FormLabel>Descrição</FormLabel>
                     <FormControl>
-                      <Textarea {...field} placeholder="Detalhes opcionais..." />
+                      <Textarea
+                        {...field}
+                        placeholder="Detalhes opcionais..."
+                      />
                     </FormControl>
                   </FormItem>
                 )}
@@ -324,17 +365,31 @@ export function TurnDetailsModal({
                   type="button"
                   variant="destructive"
                   size="icon"
+                  aria-label="Deletar turno"
                   onClick={handleDelete}
                   disabled={isSubmitting || isDeleting}
                 >
-                  {isDeleting ? <Loader2 className="w-4 h-4 animate-spin" /> : <Trash className="w-4 h-4" />}
+                  {isDeleting ? (
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                  ) : (
+                    <Trash className="w-4 h-4" />
+                  )}
                 </Button>
                 <div className="flex gap-2">
-                  <Button type="button" variant="outline" onClick={() => setIsEditing(false)} disabled={isSubmitting || isDeleting}>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => setIsEditing(false)}
+                    disabled={isSubmitting || isDeleting}
+                  >
                     <X className="w-4 h-4 mr-1" /> Cancelar
                   </Button>
                   <Button type="submit" disabled={isSubmitting || isDeleting}>
-                    {isSubmitting ? <Loader2 className="w-4 h-4 animate-spin" /> : <Save className="w-4 h-4 mr-1" />}
+                    {isSubmitting ? (
+                      <Loader2 className="w-4 h-4 animate-spin" />
+                    ) : (
+                      <Save className="w-4 h-4 mr-1" />
+                    )}
                     Salvar
                   </Button>
                 </div>
@@ -349,10 +404,16 @@ export function TurnDetailsModal({
                 <>
                   <div className="flex items-center justify-between mb-2">
                     <span className="text-sm font-medium text-muted-foreground flex items-center gap-1">
-                      {isHeal ? <Heart className="w-4 h-4" /> : <Swords className="w-4 h-4" />}
+                      {isHeal ? (
+                        <Heart className="w-4 h-4" />
+                      ) : (
+                        <Swords className="w-4 h-4" />
+                      )}
                       {isHeal ? "Cura Realizada" : "Dano Causado"}
                     </span>
-                    <span className={`text-2xl font-bold ${isHeal ? "text-green-500" : "text-amber-500"}`}>
+                    <span
+                      className={`text-2xl font-bold ${isHeal ? "text-green-500" : "text-amber-500"}`}
+                    >
                       {turn.damage}
                     </span>
                   </div>
@@ -389,13 +450,17 @@ export function TurnDetailsModal({
                   <div className="flex items-center gap-2">
                     {turn.character && (
                       <CharacterAvatar
-                        src={turn.character.characterUrl || turn.character.imageUrl}
+                        src={
+                          turn.character.characterUrl || turn.character.imageUrl
+                        }
                         alt={turn.character.name}
                         size={24}
                         isNpc={turn.character.isNpc}
                       />
                     )}
-                    <p className="text-sm font-medium truncate">{turn.character?.name || "Sistema"}</p>
+                    <p className="text-sm font-medium truncate">
+                      {turn.character?.name || "Sistema"}
+                    </p>
                   </div>
                 </div>
               )}
@@ -413,7 +478,9 @@ export function TurnDetailsModal({
                         isNpc={turn.target.isNpc}
                       />
                     )}
-                    <p className="text-sm font-medium truncate">{turn.target?.name || "N/A"}</p>
+                    <p className="text-sm font-medium truncate">
+                      {turn.target?.name || "N/A"}
+                    </p>
                   </div>
                 </div>
               )}
@@ -433,7 +500,9 @@ export function TurnDetailsModal({
                 <span className="text-muted-foreground flex items-center gap-2">
                   <User className="w-4 h-4" /> Registrado por
                 </span>
-                <span className="font-medium">{turn.owner?.name || "Sistema"}</span>
+                <span className="font-medium">
+                  {turn.owner?.name || "Sistema"}
+                </span>
               </div>
             </div>
           </div>

--- a/app/dashboard/battles/[id]/manage/page.tsx
+++ b/app/dashboard/battles/[id]/manage/page.tsx
@@ -80,7 +80,7 @@ const ManageBattlePage = () => {
   const [isOwner, setIsOwner] = useState(false);
   const [damageToDelete, setDamageToDelete] = useState<string | null>(null);
   const [characterToRemove, setCharacterToRemove] = useState<string | null>(
-    null
+    null,
   );
 
   // States for collapsible sections
@@ -119,7 +119,7 @@ const ManageBattlePage = () => {
         if (updatedBattle.ok) {
           setBattle(updatedBattle.data);
           window.dispatchEvent(
-            new CustomEvent("battleUpdated", { detail: updatedBattle.data })
+            new CustomEvent("battleUpdated", { detail: updatedBattle.data }),
           );
         }
       } else {
@@ -139,7 +139,7 @@ const ManageBattlePage = () => {
     try {
       const response = await removeCharacterFromBattle(
         characterToRemove,
-        id as string
+        id as string,
       );
       if (response.ok) {
         toast.success("Personagem removido com sucesso");
@@ -148,7 +148,7 @@ const ManageBattlePage = () => {
         if (updatedBattle.ok) {
           setBattle(updatedBattle.data);
           window.dispatchEvent(
-            new CustomEvent("battleUpdated", { detail: updatedBattle.data })
+            new CustomEvent("battleUpdated", { detail: updatedBattle.data }),
           );
         }
       } else {
@@ -204,11 +204,18 @@ const ManageBattlePage = () => {
     <div className="container mx-auto p-4 max-w-5xl space-y-6 animate-in fade-in duration-500">
       <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
         <div>
-          <h1 className="text-4xl font-extrabold tracking-tight">Painel de Gerenciamento</h1>
-          <p className="text-muted-foreground mt-1">Controle total sobre {battle.name}</p>
+          <h1 className="text-4xl font-extrabold tracking-tight">
+            Painel de Gerenciamento
+          </h1>
+          <p className="text-muted-foreground mt-1">
+            Controle total sobre {battle.name}
+          </p>
         </div>
         <Link href={`/dashboard/battles/${id}`}>
-          <Button variant="outline" className="gap-2 hover:bg-muted transition-colors">
+          <Button
+            variant="outline"
+            className="gap-2 hover:bg-muted transition-colors"
+          >
             <ArrowLeft className="h-4 w-4" />
             Voltar para Batalha
           </Button>
@@ -228,15 +235,28 @@ const ManageBattlePage = () => {
               </div>
               <div>
                 <CardTitle className="text-lg">Personagens</CardTitle>
-                <p className="text-xs text-muted-foreground">Gerencie quem participa desta batalha</p>
+                <p className="text-xs text-muted-foreground">
+                  Gerencie quem participa desta batalha
+                </p>
               </div>
             </div>
             <div className="flex items-center gap-2">
               <AddCharacterModal />
-              {isCharactersExpanded ? <ChevronDown className="h-5 w-5 text-muted-foreground" /> : <ChevronRight className="h-5 w-5 text-muted-foreground" />}
+              {isCharactersExpanded ? (
+                <ChevronDown className="h-5 w-5 text-muted-foreground" />
+              ) : (
+                <ChevronRight className="h-5 w-5 text-muted-foreground" />
+              )}
             </div>
           </CardHeader>
-          <div className={cn("transition-all duration-300 ease-in-out", isCharactersExpanded ? "max-h-[1000px] opacity-100" : "max-h-0 opacity-0 overflow-hidden")}>
+          <div
+            className={cn(
+              "transition-all duration-300 ease-in-out",
+              isCharactersExpanded
+                ? "max-h-[1000px] opacity-100"
+                : "max-h-0 opacity-0 overflow-hidden",
+            )}
+          >
             <CardContent className="pt-0">
               <div className="rounded-xl border bg-card/40 overflow-hidden">
                 <Table>
@@ -248,7 +268,10 @@ const ManageBattlePage = () => {
                   </TableHeader>
                   <TableBody>
                     {battle.characters.map((character) => (
-                      <TableRow key={character._id} className="group hover:bg-muted/40 transition-colors border-muted">
+                      <TableRow
+                        key={character._id}
+                        className="group hover:bg-muted/40 transition-colors border-muted"
+                      >
                         <TableCell className="font-medium py-3">
                           {character.name}
                         </TableCell>
@@ -259,24 +282,31 @@ const ManageBattlePage = () => {
                                 variant="ghost"
                                 size="icon"
                                 className="h-8 w-8 text-muted-foreground group-hover:text-destructive transition-colors"
+                                aria-label="Remover personagem"
                                 onClick={(e) => {
                                   e.stopPropagation();
                                   setCharacterToRemove(character._id);
                                 }}
                               >
                                 <UserMinus className="h-4 w-4" />
-                                <span className="sr-only">Remover</span>
                               </Button>
                             </AlertDialogTrigger>
                             <AlertDialogContent>
                               <AlertDialogHeader>
-                                <AlertDialogTitle>Confirmar remoção</AlertDialogTitle>
+                                <AlertDialogTitle>
+                                  Confirmar remoção
+                                </AlertDialogTitle>
                                 <AlertDialogDescription>
-                                  Tem certeza que deseja remover <strong>{character.name}</strong> da batalha?
+                                  Tem certeza que deseja remover{" "}
+                                  <strong>{character.name}</strong> da batalha?
                                 </AlertDialogDescription>
                               </AlertDialogHeader>
                               <AlertDialogFooter>
-                                <AlertDialogCancel onClick={() => setCharacterToRemove(null)}>Cancelar</AlertDialogCancel>
+                                <AlertDialogCancel
+                                  onClick={() => setCharacterToRemove(null)}
+                                >
+                                  Cancelar
+                                </AlertDialogCancel>
                                 <AlertDialogAction
                                   onClick={handleRemoveCharacter}
                                   className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
@@ -291,10 +321,15 @@ const ManageBattlePage = () => {
                     ))}
                     {battle.characters.length === 0 && (
                       <TableRow>
-                        <TableCell colSpan={2} className="text-center py-12 text-muted-foreground">
+                        <TableCell
+                          colSpan={2}
+                          className="text-center py-12 text-muted-foreground"
+                        >
                           <div className="flex flex-col items-center justify-center gap-2">
                             <Users className="h-10 w-10 opacity-10" />
-                            <p className="text-sm">Nenhum personagem na batalha</p>
+                            <p className="text-sm">
+                              Nenhum personagem na batalha
+                            </p>
                           </div>
                         </TableCell>
                       </TableRow>
@@ -318,12 +353,25 @@ const ManageBattlePage = () => {
               </div>
               <div>
                 <CardTitle className="text-lg">Histórico de Danos</CardTitle>
-                <p className="text-xs text-muted-foreground">Visualize e gerencie cada evento da batalha</p>
+                <p className="text-xs text-muted-foreground">
+                  Visualize e gerencie cada evento da batalha
+                </p>
               </div>
             </div>
-            {isHistoryExpanded ? <ChevronDown className="h-5 w-5 text-muted-foreground" /> : <ChevronRight className="h-5 w-5 text-muted-foreground" />}
+            {isHistoryExpanded ? (
+              <ChevronDown className="h-5 w-5 text-muted-foreground" />
+            ) : (
+              <ChevronRight className="h-5 w-5 text-muted-foreground" />
+            )}
           </CardHeader>
-          <div className={cn("transition-all duration-300 ease-in-out", isHistoryExpanded ? "max-h-[1000px] opacity-100 overflow-auto" : "max-h-0 opacity-0 overflow-hidden")}>
+          <div
+            className={cn(
+              "transition-all duration-300 ease-in-out",
+              isHistoryExpanded
+                ? "max-h-[1000px] opacity-100 overflow-auto"
+                : "max-h-0 opacity-0 overflow-hidden",
+            )}
+          >
             <CardContent className="pt-0">
               <div className="rounded-xl border bg-card/40 overflow-hidden">
                 <Table>
@@ -332,22 +380,34 @@ const ManageBattlePage = () => {
                       <TableHead className="w-[100px] py-4">Rodada</TableHead>
                       <TableHead className="py-4">Personagem</TableHead>
                       <TableHead className="py-4">Alvo</TableHead>
-                      <TableHead className="text-center w-[120px] py-4">Valor</TableHead>
-                      <TableHead className="text-center w-[150px] py-4">Tipo/Descrição</TableHead>
-                      <TableHead className="text-center w-[100px] py-4">Crítico</TableHead>
-                      <TableHead className="text-right w-[100px] py-4">Ações</TableHead>
+                      <TableHead className="text-center w-[120px] py-4">
+                        Valor
+                      </TableHead>
+                      <TableHead className="text-center w-[150px] py-4">
+                        Tipo/Descrição
+                      </TableHead>
+                      <TableHead className="text-center w-[100px] py-4">
+                        Crítico
+                      </TableHead>
+                      <TableHead className="text-right w-[100px] py-4">
+                        Ações
+                      </TableHead>
                     </TableRow>
                   </TableHeader>
                   <TableBody>
                     {battle.rounds.map((round) => (
-                      <TableRow key={round._id} className="group hover:bg-muted/40 transition-colors border-muted">
+                      <TableRow
+                        key={round._id}
+                        className="group hover:bg-muted/40 transition-colors border-muted"
+                      >
                         <TableCell className="py-3">
                           <span className="inline-flex items-center justify-center rounded-lg bg-primary/10 text-primary w-7 h-7 text-xs font-bold">
                             {round.round}
                           </span>
                         </TableCell>
                         <TableCell className="font-medium py-3">
-                          {round.character?.name || (round.type === "other" ? "Evento" : "N/A")}
+                          {round.character?.name ||
+                            (round.type === "other" ? "Evento" : "N/A")}
                         </TableCell>
                         <TableCell className="py-3">
                           {round.target?.name || "-"}
@@ -357,9 +417,13 @@ const ManageBattlePage = () => {
                         </TableCell>
                         <TableCell className="text-center py-3">
                           {round.type === "damage" ? (
-                            <span className="text-destructive font-medium">Dano</span>
+                            <span className="text-destructive font-medium">
+                              Dano
+                            </span>
                           ) : round.type === "heal" ? (
-                            <span className="text-green-500 font-medium">Cura</span>
+                            <span className="text-green-500 font-medium">
+                              Cura
+                            </span>
                           ) : (
                             <span className="text-muted-foreground italic">
                               {round.description || "Evento"}
@@ -368,9 +432,13 @@ const ManageBattlePage = () => {
                         </TableCell>
                         <TableCell className="text-center py-3">
                           {round.isCritical ? (
-                            <span className="text-amber-500 font-bold text-xs px-2 py-0.5 rounded-full bg-amber-500/10 uppercase">Sim</span>
+                            <span className="text-amber-500 font-bold text-xs px-2 py-0.5 rounded-full bg-amber-500/10 uppercase">
+                              Sim
+                            </span>
                           ) : (
-                            <span className="text-muted-foreground text-xs uppercase">Não</span>
+                            <span className="text-muted-foreground text-xs uppercase">
+                              Não
+                            </span>
                           )}
                         </TableCell>
                         <TableCell className="text-right py-3">
@@ -380,24 +448,31 @@ const ManageBattlePage = () => {
                                 variant="ghost"
                                 size="icon"
                                 className="h-8 w-8 text-muted-foreground group-hover:text-destructive transition-colors"
+                                aria-label="Deletar turno"
                                 onClick={(e) => {
                                   e.stopPropagation();
                                   setDamageToDelete(round._id);
                                 }}
                               >
                                 <Trash2 className="h-4 w-4" />
-                                <span className="sr-only">Deletar</span>
                               </Button>
                             </AlertDialogTrigger>
                             <AlertDialogContent>
                               <AlertDialogHeader>
-                                <AlertDialogTitle>Confirmar exclusão</AlertDialogTitle>
+                                <AlertDialogTitle>
+                                  Confirmar exclusão
+                                </AlertDialogTitle>
                                 <AlertDialogDescription>
-                                  Tem certeza que deseja excluir este registro de dano?
+                                  Tem certeza que deseja excluir este registro
+                                  de dano?
                                 </AlertDialogDescription>
                               </AlertDialogHeader>
                               <AlertDialogFooter>
-                                <AlertDialogCancel onClick={() => setDamageToDelete(null)}>Cancelar</AlertDialogCancel>
+                                <AlertDialogCancel
+                                  onClick={() => setDamageToDelete(null)}
+                                >
+                                  Cancelar
+                                </AlertDialogCancel>
                                 <AlertDialogAction
                                   onClick={handleDeleteDamage}
                                   className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
@@ -412,7 +487,10 @@ const ManageBattlePage = () => {
                     ))}
                     {battle.rounds.length === 0 && (
                       <TableRow>
-                        <TableCell colSpan={6} className="text-center py-12 text-muted-foreground">
+                        <TableCell
+                          colSpan={6}
+                          className="text-center py-12 text-muted-foreground"
+                        >
                           <div className="flex flex-col items-center justify-center gap-2">
                             <Swords className="h-10 w-10 opacity-10" />
                             <p className="text-sm">Nenhum dano registrado</p>

--- a/app/dashboard/campaigns/[id]/manage/page.tsx
+++ b/app/dashboard/campaigns/[id]/manage/page.tsx
@@ -126,6 +126,7 @@ export default function ManageCampaign() {
                           variant="ghost"
                           size="icon"
                           className="text-destructive"
+                          aria-label="Remover personagem"
                         >
                           <Trash2 className="h-4 w-4" />
                         </Button>


### PR DESCRIPTION
💡 What: Added descriptive `aria-label` attributes to various icon-only buttons across the battles and campaigns dashboard components.
🎯 Why: To ensure screen readers announce the action of these buttons properly, improving overall keyboard and assistive technology accessibility.
♿ Accessibility: Replaced older visually-hidden text patterns with cleaner direct `aria-label` attributes on `Button` elements.

---
*PR created automatically by Jules for task [7077802206294599613](https://jules.google.com/task/7077802206294599613) started by @HensleyFerrari*