### PR TITLE
🎨 Palette: Add visual loading state to campaign modal

### DIFF
--- a/app/dashboard/campaigns/components/campaign-modal.tsx
+++ b/app/dashboard/campaigns/components/campaign-modal.tsx
@@ -19,6 +19,7 @@ import { useState, useEffect, useCallback } from "react";
 import { useForm, Controller } from "react-hook-form";
 import { toast } from "sonner";
 import { Switch } from "@/components/ui/switch";
+import { Loader2 } from "lucide-react";
 
 type FormData = {
   name: string;
@@ -257,6 +258,7 @@ export function CampaignModal() {
                 Cancelar
               </Button>
               <Button type="submit" disabled={isLoading}>
+                {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />}
                 {isLoading ? "Salvando..." : (isNew ? "Criar Campanha" : "Salvar Alterações")}
               </Button>
             </DialogFooter>


### PR DESCRIPTION
🎨 **Palette UX Improvement**

💡 **What:** Added a visual loading state to the `CampaignModal` submit button using the `Loader2` component from `lucide-react`.
🎯 **Why:** To provide clear visual feedback to users that their request (saving a campaign) is being processed. This is a crucial micro-UX enhancement that prevents multiple clicks and reassures the user.
♿ **Accessibility:** Added `aria-hidden="true"` to the `Loader2` icon to ensure it isn't read out repetitively or confusingly by screen readers while maintaining the button's descriptive text.

---
*PR created automatically by Jules for task [15277954557463927404](https://jules.google.com/task/15277954557463927404) started by @HensleyFerrari*