### PR TITLE
feat(models): implement multitenant Workspace and Membership system

### DIFF
--- a/models/Invite.ts
+++ b/models/Invite.ts
@@ -1,0 +1,71 @@
+import mongoose, { ObjectId, Schema, model } from "mongoose";
+
+export interface InviteDocument {
+  _id: string;
+  workspace: ObjectId;
+  email: string;
+  role: "admin" | "dungeon_master" | "player";
+  token: string;
+  status: "pending" | "accepted" | "revoked";
+  invitedBy: ObjectId;
+  expiresAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const InviteSchema = new Schema<InviteDocument>(
+  {
+    workspace: {
+      type: Schema.Types.ObjectId,
+      ref: "Workspace",
+      required: [true, "Workspace is required"],
+    },
+    email: {
+      type: String,
+      required: [true, "Email is required"],
+      match: [
+        /^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/,
+        "Email is invalid",
+      ],
+    },
+    role: {
+      type: String,
+      enum: ["admin", "dungeon_master", "player"],
+      default: "player",
+      required: true,
+    },
+    token: {
+      type: String,
+      required: true,
+      unique: true,
+    },
+    status: {
+      type: String,
+      enum: ["pending", "accepted", "revoked"],
+      default: "pending",
+      required: true,
+    },
+    invitedBy: {
+      type: Schema.Types.ObjectId,
+      ref: "User",
+      required: [true, "Invited by is required"],
+    },
+    expiresAt: {
+      type: Date,
+      required: true,
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+// Prevent multiple pending invites for the same email in the same workspace
+InviteSchema.index(
+  { workspace: 1, email: 1 },
+  { unique: true, partialFilterExpression: { status: "pending" } }
+);
+
+const Invite =
+  mongoose.models?.Invite || model<InviteDocument>("Invite", InviteSchema);
+export default Invite;

--- a/models/Membership.ts
+++ b/models/Membership.ts
@@ -1,0 +1,47 @@
+import mongoose, { ObjectId, Schema, model } from "mongoose";
+
+export interface MembershipDocument {
+  _id: string;
+  workspace: ObjectId;
+  user: ObjectId;
+  role: "owner" | "admin" | "dungeon_master" | "player";
+  joinedAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const MembershipSchema = new Schema<MembershipDocument>(
+  {
+    workspace: {
+      type: Schema.Types.ObjectId,
+      ref: "Workspace",
+      required: [true, "Workspace is required"],
+    },
+    user: {
+      type: Schema.Types.ObjectId,
+      ref: "User",
+      required: [true, "User is required"],
+    },
+    role: {
+      type: String,
+      enum: ["owner", "admin", "dungeon_master", "player"],
+      default: "player",
+      required: true,
+    },
+    joinedAt: {
+      type: Date,
+      default: Date.now,
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+// Prevent duplicate memberships for the same user in a workspace
+MembershipSchema.index({ workspace: 1, user: 1 }, { unique: true });
+
+const Membership =
+  mongoose.models?.Membership ||
+  model<MembershipDocument>("Membership", MembershipSchema);
+export default Membership;

--- a/models/Workspace.ts
+++ b/models/Workspace.ts
@@ -1,0 +1,41 @@
+import mongoose, { ObjectId, Schema, model } from "mongoose";
+
+export interface WorkspaceDocument {
+  _id: string;
+  name: string;
+  description: string;
+  imageUrl: string;
+  owner: ObjectId;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const WorkspaceSchema = new Schema<WorkspaceDocument>(
+  {
+    name: {
+      type: String,
+      required: [true, "Name is required"],
+    },
+    description: {
+      type: String,
+      default: "",
+    },
+    imageUrl: {
+      type: String,
+      default: "",
+    },
+    owner: {
+      type: Schema.Types.ObjectId,
+      ref: "User",
+      required: [true, "Owner is required"],
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+const Workspace =
+  mongoose.models?.Workspace ||
+  model<WorkspaceDocument>("Workspace", WorkspaceSchema);
+export default Workspace;


### PR DESCRIPTION
This pull request introduces the Mongoose models required to support a multitenant, collaborative environment in the application.

It defines:
- **Workspace:** The root tenant entity (`Guilda`), including basic details and an owner reference.
- **Membership:** Manages the many-to-many relationship between Users and Workspaces, incorporating business roles (`owner`, `admin`, `dungeon_master`, `player`) with strict compound indexes (`workspace: 1, user: 1`) to prevent duplication.
- **Invite:** Facilitates inviting new users and existing members into a workspace. It includes status tracking (`pending`, `accepted`, `revoked`), a role definition for the invitee, a unique token, and a partial index ensuring a user can't have multiple pending invites for the same workspace simultaneously.

These models follow Next.js Mongoose standard practices (`mongoose.models.X || model('X', ...)`) to ensure safe hot-reloading behavior and robust type definitions.

---
*PR created automatically by Jules for task [12808234997986105730](https://jules.google.com/task/12808234997986105730) started by @HensleyFerrari*